### PR TITLE
Put latest changes in develop branch -- was only in master with previous PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 [![Build Status](https://secure.travis-ci.org/flatland/useful.png)](http://travis-ci.org/flatland/useful)
+
+These two repositories are usually identical:
+
+* https://github.com/amalloy/useful
+* https://github.com/flatland/useful
+
+The first is the canonical one.  Fixes tend to appear there first, and
+that is the preferred repository for filing issues on Github.  Fixes
+are backported to the second one periodically.

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
-  :url "https://github.com/flatland/useful"
+  :url "https://github.com/amalloy/useful"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.macro "0.1.1"]
                  [org.clojure/tools.reader "0.7.2"]]


### PR DESCRIPTION
On Github web page, develop seems to be default branch shown, so README.md changes will not show up for most people unless the changes are on develop branch.